### PR TITLE
Improve warning message when device does not exist

### DIFF
--- a/nodes/40virtual-device-gen-event.js
+++ b/nodes/40virtual-device-gen-event.js
@@ -70,9 +70,9 @@
 			var deviceId = (msg.payload && msg.payload.deviceId) ? msg.payload.deviceId : (msg.deviceId) ? msg.deviceId : node.deviceId;
 			if(!deviceId)
 				throw new Error("Device Id is undefined");
-      var device = (node.schema) ? deviceManager.getDevice(node.schema.deviceType, deviceId) : deviceManager.getDevicebyId(deviceId);
-    	if(!device){
-				node.warn("Device " + deviceId + " is off");
+                        var device = (node.schema) ? deviceManager.getDevice(node.schema.deviceType, deviceId) : deviceManager.getDevicebyId(deviceId);
+    	                if(!device){
+				node.warn("Device " + deviceId + " does not exist");
 				node.send(null);
 			}
 			else {


### PR DESCRIPTION
"Device x is off" does not give a hint to what the problem is.

It is also a bit strange that the device is actively deleted in the close event of the virtual device node.  This event is emitted when the flow is deployed as well as when the app is restarted, so you will end up having to create each time you deploy.

I think this could be confusing.  If it didn't, we could still cache devices (although again, this could cause confusion), but if the device is not in the cache, it should query the platform.  Or just query the platform every time, which would reduce confusion.